### PR TITLE
Allow arbitrary git objects for license file URL

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -36,8 +36,7 @@ func Parse(line string) (match bool, key string, url string) {
 		log.Printf("%s: %s", lib, u)
 
 		u = strings.Replace(u, "https://github.com/", "https://raw.githubusercontent.com/", 1)
-		u = strings.Replace(u, "/blob/master/", "/master/", 1)
-		u = strings.Replace(u, "/blob/develop/", "/develop/", 1)
+		u = strings.Replace(u, "/blob/", "/", 1)
 
 		return true, lib, u
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -6,39 +6,39 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	if match, lib, url := Fetch("[SwiftyJSON]:https://github.com/SwiftyJSON/SwiftyJSON/blob/master/LICENSE"); match {
+	if match, lib, license := Fetch("[SwiftyJSON]:https://github.com/SwiftyJSON/SwiftyJSON/blob/master/LICENSE"); match {
 		log.Println(lib)
-		log.Println(url)
+		log.Println(license)
 	} else {
 		t.Errorf("error")
 	}
 
-	if match, lib, url := Fetch("[OAuth2]:https://github.com/p2/OAuth2/blob/master/LICENSE.txt"); match {
+	if match, lib, license := Fetch("[OAuth2]:https://github.com/p2/OAuth2/blob/2.0.0/LICENSE.txt"); match && license != "Not Found" {
 		log.Println(lib)
-		log.Println(url)
+		log.Println(license)
 	} else {
 		t.Errorf("error")
 	}
 
-	if match, lib, url := Fetch("[SQLite.swift]:https://github.com/stephencelis/SQLite.swift/blob/master/LICENSE.txt"); match {
+	if match, lib, license := Fetch("[SQLite.swift]:https://github.com/stephencelis/SQLite.swift/blob/master/LICENSE.txt"); match {
 		log.Println(lib)
-		log.Println(url)
+		log.Println(license)
 	} else {
 		t.Errorf("error")
 	}
 
-	if match, lib, url := Fetch("[ios-license-generator]:https://github.com/mono0926/ios-license-generator/blob/master/LICENSE"); match {
+	if match, lib, license := Fetch("[ios-license-generator]:https://github.com/mono0926/ios-license-generator/blob/master/LICENSE"); match {
 		log.Println(lib)
-		log.Println(url)
+		log.Println(license)
 	} else {
 		t.Errorf("error")
 	}
 
-	if match, lib, url := Fetch("hoge"); match {
-		t.Errorf("error: (lib: %s, url: %s)", lib, url)
+	if match, lib, license := Fetch("hoge"); match {
+		t.Errorf("error: (lib: %s, license: %s)", lib, license)
 	}
-	if match, lib, url := Fetch("[SwiftyJSON]:hoge"); match {
-		t.Errorf("error: (lib: %s, url: %s)", lib, url)
+	if match, lib, license := Fetch("[SwiftyJSON]:hoge"); match {
+		t.Errorf("error: (lib: %s, license: %s)", lib, license)
 	}
 
 }


### PR DESCRIPTION
Branches other than `master` or `develop`, tags and specific commits can be used now.
